### PR TITLE
Fix module entrypoint and worker creation fallback

### DIFF
--- a/game/main.js
+++ b/game/main.js
@@ -168,6 +168,22 @@ class InlineWorker {
 }
 
 async function createSimulationWorker() {
+  const canUseModuleWorker =
+    typeof Worker === 'function' &&
+    typeof import.meta !== 'undefined' &&
+    import.meta &&
+    typeof import.meta.url === 'string' &&
+    import.meta.url.startsWith('http');
+
+  if (canUseModuleWorker) {
+    try {
+      return new Worker(new URL('./worker/worker.entry.js', import.meta.url), { type: 'module' });
+    } catch (error) {
+      console.warn('Не удалось создать модульный воркер, используем фолбэк', error);
+    }
+  }
+
+  return new InlineWorker();
 }
 
 const renderApp = new PixiApp({ containerId: 'game-root' });

--- a/index.html
+++ b/index.html
@@ -17,15 +17,12 @@
         });
       }
     </script>
-    <script type="importmap" src="./importmap.generated.json"></script>
   </head>
   <body>
     <main>
       <div id="game-root"></div>
       <div id="panel-root"></div>
     </main>
-    <script type="module">
-      import 'main.js';
-    </script>
+    <script type="module" src="./game/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the game entrypoint with a relative module path so browsers resolve it without an import map
- add worker capability detection and a fallback inline worker to match the bundled build behaviour

## Testing
- not run (not available)

