### PR TITLE
Fix missing entry script on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,5 +55,6 @@
       <div id="game-root"></div>
       <div id="panel-root"></div>
     </main>
+    <script type="module" src="./game/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the browser colony simulator entrypoint when opening the root index by adding the module script tag

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d08b3cc608832bae5e7373325a83fc